### PR TITLE
Make Email, EmailAddress, and Attachment Codable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You need to add library to `Package.swift` file:
 
  - add package to dependencies:
 ```swift
-.package(url: "https://github.com/Mikroservices/Smtp.git", from: "3.0.0")
+.package(url: "https://github.com/PassiveLogic/Smtp.git", from: "3.0.0")
 ```
 
 - and add product to your target:
@@ -132,7 +132,7 @@ request.smtp.send(email) { message in
 After cloning the repository you can open it in Xcode.
 
 ```bash
-$ git clone https://github.com/Mikroservices/Smtp.git
+$ git clone https://github.com/PassiveLogic/Smtp.git
 $ cd Smtp
 $ open Package.swift
 ```

--- a/Sources/Smtp/Models/Attachment.swift
+++ b/Sources/Smtp/Models/Attachment.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public struct Attachment {
+public struct Attachment: Codable {
     public let name: String
     public let contentType: String
     public let data: Data

--- a/Sources/Smtp/Models/Email.swift
+++ b/Sources/Smtp/Models/Email.swift
@@ -7,7 +7,7 @@
 import Foundation
 import NIO
 
-public struct Email {
+public struct Email: Codable {
     public let from: EmailAddress
     public let to: [EmailAddress]?
     public let cc: [EmailAddress]?

--- a/Sources/Smtp/Models/EmailAddress.swift
+++ b/Sources/Smtp/Models/EmailAddress.swift
@@ -4,7 +4,7 @@
 //  Licensed under the MIT License.
 //
 
-public struct EmailAddress {
+public struct EmailAddress: Codable {
     public let address: String
     public let name: String?
 


### PR DESCRIPTION
Simply adds synthesized conformance for these types to avoid dependent packages having to implement themselves.